### PR TITLE
Locking mechanism, with accompanying option and config.yml capabilities

### DIFF
--- a/Command/BaseCommand.php
+++ b/Command/BaseCommand.php
@@ -68,8 +68,7 @@ abstract class BaseCommand extends ContainerAwareCommand
         $this
             ->addOption('log-level', 'l', InputOption::VALUE_REQUIRED,
                 'Override the Monolog logging level for this execution of the command. Valid values: ' . implode(',', array_keys(Logger::getLevels())))
-            ->addOption('locking', null, InputOption::VALUE_REQUIRED, 'Switches locking on/off')
-        ;
+            ->addOption('locking', null, InputOption::VALUE_REQUIRED, 'Switches locking on/off');
     }
 
     /**
@@ -290,7 +289,7 @@ abstract class BaseCommand extends ContainerAwareCommand
     public function setDefaultLocking($value)
     {
         if (!is_bool($value)) {
-            throw new \InvalidArgumentException('Value passed to '.__FUNCTION__.' should be of type boolean');
+            throw new \InvalidArgumentException('Value passed to ' . __FUNCTION__ . ' should be of type boolean');
         }
 
         $this->defaultLocking = $value;
@@ -306,6 +305,7 @@ abstract class BaseCommand extends ContainerAwareCommand
         if (!isset($this->defaultLocking)) {
             $this->defaultLocking = $this->getContainer()->getParameter('afrihost_base_command.locking.enabled');
         }
+
         return $this->defaultLocking;
     }
 

--- a/Command/BaseCommand.php
+++ b/Command/BaseCommand.php
@@ -52,7 +52,7 @@ abstract class BaseCommand extends ContainerAwareCommand
     /**
      * @var LockHandler
      */
-    private $lockhandler;
+    private $lockHandler;
 
     /**
      * Provides default options for all commands. This function should be called explicitly (i.e. parent::configure())
@@ -118,6 +118,8 @@ abstract class BaseCommand extends ContainerAwareCommand
             if (($input->getOption('locking') == 'on') || ($this->getContainer()->getParameter('afrihost_base_command.locking.enabled'))) {
                 $this->lockhandler = new LockHandler($this->filename);
                 if (!$this->lockhandler->lock()) {
+                $this->lockHandler = new LockHandler($this->filename);
+                if (!$this->lockHandler->lock()) {
                     throw new LockAcquireException('Sorry, can\'t get the lock. Bailing out!');
                 }
             }

--- a/Command/BaseCommand.php
+++ b/Command/BaseCommand.php
@@ -6,6 +6,7 @@
 
 namespace Afrihost\BaseCommandBundle\Command;
 
+use Afrihost\BaseCommandBundle\Exceptions\LockAcquireException;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\AbstractHandler;
 use Monolog\Handler\StreamHandler;
@@ -117,8 +118,7 @@ abstract class BaseCommand extends ContainerAwareCommand
             if (($input->getOption('locking') == 'on') || ($this->getContainer()->getParameter('afrihost_base_command.locking.enabled'))) {
                 $this->lockhandler = new LockHandler($this->filename);
                 if (!$this->lockhandler->lock()) {
-                    $output->writeln('<error>Sorry, can\'t get the lock. Bailing out!</error>');
-                    exit;
+                    throw new LockAcquireException('Sorry, can\'t get the lock. Bailing out!');
                 }
             }
         }

--- a/DependencyInjection/AfrihostBaseCommandExtension.php
+++ b/DependencyInjection/AfrihostBaseCommandExtension.php
@@ -22,6 +22,6 @@ class AfrihostBaseCommandExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('afrihost_base_command.logger.handler_strategies.default.file_extention', $config['logger']['handler_strategies']['default']['file_extention']);
-
+        $container->setParameter('afrihost_base_command.locking.enabled', $config['locking']['enabled']);
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -27,6 +27,12 @@ class Configuration implements ConfigurationInterface
         // @formatter:off
         $rootNode
             ->children()
+                ->arrayNode('locking')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('enabled')->defaultValue(true)->end
+                    ->end()
+                ->end()
                 ->arrayNode('logger')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -30,7 +30,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('locking')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->booleanNode('enabled')->defaultValue(true)->end
+                        ->booleanNode('enabled')->defaultValue(true)->end()
                     ->end()
                 ->end()
                 ->arrayNode('logger')

--- a/Exceptions/LockAcquireException.php
+++ b/Exceptions/LockAcquireException.php
@@ -1,0 +1,12 @@
+<?php
+namespace Afrihost\BaseCommandBundle\Exceptions;
+
+use Exception;
+
+class LockAcquireException extends \Exception
+{
+    public function __construct($message = "", $code = 0, Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The following are features we would like to add. When this list is done (or reas
   - [ ] PHP Error Reporting
 - [ ] **User Specified LineFormatters**: Our default format (%datetime% \[%level_name%\]: %message%) is hardcoded. This isn't
  ideal if you wish to parse the logs with a specific tool.
-- [ ] **Locking**: Integrate mechanism to ensure that only one process is executing a command at a time 
+- [x] **Locking**: Integrate mechanism to ensure that only one process is executing a command at a time 
 - [ ] **Config for Monolog's AllowLineBreaks Option**: because sometimes you want a new line in the middle of a log entry
 - [ ] **PHPUnit**: config and basic code coverage. The goal is to have some form of Github integrated CI
 - [ ] **Documentation**:


### PR DESCRIPTION
One can now switch the locking mechanism on/off by default in the config:

``` yml
afrihost_base_command:
    locking:
        enabled:              true
```

On top of that, the enabling/disabling of locking can be switched on/off via a command line option: `--locking=on` or `--locking=off`.
And finally, to start off things better, I've built in validation for the option (and made a space for other validation in future) whereby if we specify something like `--locking=onnnn` it will fail on validation and stop the process, throwing a ValidatorException with an appropriate message.
