### PR TITLE
Lockfile storage location configuration

### DIFF
--- a/Command/BaseCommand.php
+++ b/Command/BaseCommand.php
@@ -60,6 +60,11 @@ abstract class BaseCommand extends ContainerAwareCommand
     private $locking;
 
     /**
+     * @var string
+     */
+    private $lockFileFolder;
+
+    /**
      * Provides default options for all commands. This function should be called explicitly (i.e. parent::configure())
      * if the configure function is overridden.
      */
@@ -121,7 +126,7 @@ abstract class BaseCommand extends ContainerAwareCommand
         // Lock handler:
         if ($input->getOption('locking') !== 'off') {
             if (($input->getOption('locking') == 'on') || ($this->isLocking())) {
-                $this->lockHandler = new LockHandler($this->filename);
+                $this->lockHandler = new LockHandler($this->filename, $this->getLockFileFolder());
                 if (!$this->lockHandler->lock()) {
                     throw new LockAcquireException('Sorry, can\'t get the lock. Bailing out!');
                 }
@@ -327,6 +332,46 @@ abstract class BaseCommand extends ContainerAwareCommand
         }
 
         return $this->locking;
+    }
+
+    /**
+     * Used to override the default folder where your lock-files are stored. Suggestion: app/storage/lockfiles.
+     * The default will go to the system folder for this purpose.
+     * If the folder starts with / or ~/ we assume you have a static location for it.
+     * If the folder doesn't start with / or ~/ we will assume the folder is relative to your symfony app root directory.
+     *
+     * @param string $lockFileFolder
+     * @return $this
+     */
+    public function setLockFileFolder($lockFileFolder)
+    {
+        $this->lockFileFolder = $lockFileFolder;
+
+        return $this;
+    }
+
+    /**
+     * Gets the folder where the lockfiles will be stored.
+     *
+     * @return string
+     */
+    protected function getLockFileFolder()
+    {
+        if (!isset($this->lockFileFolder)) {
+            $this->lockFileFolder = $this->getContainer()->getParameter('afrihost_base_command.locking.lock_file_folder');
+        }
+
+        // Empty / Null - lockfiles will go to system default location:
+        if (is_null($this->lockFileFolder) || empty($this->lockFileFolder)) {
+            return $this->lockFileFolder;
+        }
+
+        // Relative path handling:
+        if (substr($this->lockFileFolder, 0, 1) !== '/' && substr($this->lockFileFolder, 0, 2) !== '~/') {
+            $this->lockFileFolder = $this->getContainer()->get('kernel')->getRootDir() . '/' . $this->lockFileFolder;
+        }
+
+        return $this->lockFileFolder;
     }
 
 }

--- a/Command/BaseCommand.php
+++ b/Command/BaseCommand.php
@@ -232,6 +232,7 @@ abstract class BaseCommand extends ContainerAwareCommand
      *
      * @param int $logLevel a log level constant defined in Logger
      *
+     * @return $this
      * @throws \Exception
      */
     protected function setLogLevel($logLevel)
@@ -251,6 +252,8 @@ abstract class BaseCommand extends ContainerAwareCommand
             }
             $this->getLogger()->emergency('LOG LEVEL CHANGED: ' . Logger::getLevelName($logLevel));
         }
+
+        return $this;
     }
 
     /**
@@ -269,6 +272,7 @@ abstract class BaseCommand extends ContainerAwareCommand
      *
      * @param boolean $logToConsole
      *
+     * @return $this
      * @throws \Exception
      */
     protected function setLogToConsole($logToConsole)
@@ -282,6 +286,8 @@ abstract class BaseCommand extends ContainerAwareCommand
         }
 
         $this->logToConsole = $logToConsole;
+
+        return $this;
     }
 
     /**
@@ -291,6 +297,7 @@ abstract class BaseCommand extends ContainerAwareCommand
      *
      * @param bool $value
      *
+     * @return $this
      * @throws \Exception
      */
     public function setLocking($value)
@@ -304,6 +311,8 @@ abstract class BaseCommand extends ContainerAwareCommand
         }
 
         $this->locking = $value;
+
+        return $this;
     }
 
     /**

--- a/Command/BaseCommand.php
+++ b/Command/BaseCommand.php
@@ -299,7 +299,7 @@ abstract class BaseCommand extends ContainerAwareCommand
             throw new \InvalidArgumentException('Value passed to ' . __FUNCTION__ . ' should be of type boolean');
         }
 
-        if(!is_null($this->lockHandler)){
+        if (!is_null($this->lockHandler)) {
             throw new \Exception('Cannot ' . (($value) ? 'enable' : 'disable') . ' locking. Lock handler is already initialised');
         }
 

--- a/DependencyInjection/AfrihostBaseCommandExtension.php
+++ b/DependencyInjection/AfrihostBaseCommandExtension.php
@@ -23,5 +23,6 @@ class AfrihostBaseCommandExtension extends Extension
 
         $container->setParameter('afrihost_base_command.logger.handler_strategies.default.file_extention', $config['logger']['handler_strategies']['default']['file_extention']);
         $container->setParameter('afrihost_base_command.locking.enabled', $config['locking']['enabled']);
+        $container->setParameter('afrihost_base_command.locking.lock_file_folder', $config['locking']['lock_file_folder']);
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -30,6 +30,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('locking')
                     ->addDefaultsIfNotSet()
                     ->children()
+                        ->scalarNode('lock_file_folder')->defaultNull()->end()
                         ->booleanNode('enabled')->defaultValue(true)->end()
                     ->end()
                 ->end()

--- a/README.md
+++ b/README.md
@@ -30,8 +30,18 @@ $bundles = array(
 Defaults are specified for all options so that no configuration is needed, but if you'd like, you can override the default configuration options in your `app/config/config.yml` file:
 ```yml
 afrihost_base_command:
+    locking:
+        lock_file_folder:     storage
+        enabled:              true
     log_file_extention: '.log.txt'
 ```
+
+**Locking:**
+You may opt to enable/disable locking via configuration. Locking is enabled by default.
+You might also want to change the default location where the lockfiles are created. If you do not override them, it will be created in the system default. This will be the tmp directory as specified in your php.ini file. If, however you want to override this, you may specify the folder either relative to the symfony app-root (which is "app"), or if you specify the folder with / or ~/ in front it will store it where you specify.
+
+Example (relative): "storage" >> this will assume you want it under app/storage. "storage/lockfiles" >> this will assume you want it under "app/storage/lockfiles".
+Example (explicit): "/home/my-lockfiles" >> this will store it under "/home/my-lockfiles". "~/my-lockfiles" >> say your home (or ~ directory) is "/home/cool" >> this will store the files at "~/my-lockfiles", or "/home/cool/my-lockfiles".
 
 ## Basic Usage
 Instead of extending `ContainerAwareCommand` like this:

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The following are features we would like to add. When this list is done (or reas
   - [ ] Log to Console
   - [ ] PHP Error Reporting
   - [ ] PHP memory_limit
-  - [ ] Specify lock-handler lockfile location
+  - [x] Specify lock-handler lockfile location
 - [ ] **User Specified LineFormatters**: Our default format (%datetime% \[%level_name%\]: %message%) is hardcoded. This isn't
  ideal if you wish to parse the logs with a specific tool.
 - [x] **Locking**: Integrate mechanism to ensure that only one process is executing a command at a time 

--- a/Tests/Command/BaseCommandContainerTest.php
+++ b/Tests/Command/BaseCommandContainerTest.php
@@ -1,11 +1,11 @@
 <?php
 
 use Afrihost\BaseCommandBundle\Command\BaseCommand;
+use Afrihost\BaseCommandBundle\Tests\Fixtures\App\TestKernel;
 use Afrihost\BaseCommandBundle\Tests\Fixtures\EncapsulationViolator;
 use Afrihost\BaseCommandBundle\Tests\Fixtures\HelloWorldCommand;
 use Afrihost\BaseCommandBundle\Tests\Fixtures\LoggingCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Afrihost\BaseCommandBundle\Tests\Fixtures\App\TestKernel;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -151,6 +151,29 @@ class BaseCommandContainerTest extends PHPUnit_Framework_TestCase
         $this->assertFalse(EncapsulationViolator::invokeMethod($command, 'isLocking'));
     }
 
+    public function testSetLockFileFolderRelative()
+    {
+        $command = $this->registerCommand(new HelloWorldCommand());
+        EncapsulationViolator::invokeMethod($command, 'setLockFileFolder', array('storage'));
+
+        $this->assertEquals($this->application->getKernel()->getRootDir().'/storage', EncapsulationViolator::invokeMethod($command, 'getLockFileFolder'));
+    }
+
+    public function testSetLockFileFolderStaticSlash()
+    {
+        $command = $this->registerCommand(new HelloWorldCommand());
+        EncapsulationViolator::invokeMethod($command, 'setLockFileFolder', array('/storage'));
+
+        $this->assertEquals('/storage', EncapsulationViolator::invokeMethod($command, 'getLockFileFolder'));
+    }
+
+    public function testSetLockFileFolderStaticTilde()
+    {
+        $command = $this->registerCommand(new HelloWorldCommand());
+        EncapsulationViolator::invokeMethod($command, 'setLockFileFolder', array('~/storage'));
+
+        $this->assertEquals('~/storage', EncapsulationViolator::invokeMethod($command, 'getLockFileFolder'));
+    }
 
 
     /* ################ *
@@ -221,4 +244,6 @@ class BaseCommandContainerTest extends PHPUnit_Framework_TestCase
     protected function doesLogfileExist($name){
         return file_exists($this->application->getKernel()->getLogDir().DIRECTORY_SEPARATOR.$name);
     }
+
+
 }


### PR DESCRIPTION
Configuration works via config.yml using:

``` yaml
afrihost_base_command:
    locking:
        lock_file_folder:     some_folder_name
```

Not using a / or ~ in front will assume the folder is relative to the symfony "app" root folder. (Folders are auto-created by the LockHandler, if you were wondering)

Not overriding the config will use the default tmp folder from php.ini (that's the default that LockHandler does)

If you want to override the folder just for this command, you may do so in the config function by calling:

``` php
$this->setLockFileFolder('some_folder_name');
```

(On a side-note, I've made all the setters fluent-settings, by putting a `return $this` at the end of each)
