### PR TITLE
PHP Memory Limit configuration

### DIFF
--- a/Command/BaseCommand.php
+++ b/Command/BaseCommand.php
@@ -409,7 +409,7 @@ abstract class BaseCommand extends ContainerAwareCommand
      *
      * @return string
      */
-    public function getMemoryLimit()
+    protected function getMemoryLimit()
     {
         if (!isset($this->memoryLimit)) {
             if ($this->getContainer()->hasParameter('afrihost_base_command.memory_limit')) {

--- a/Command/BaseCommand.php
+++ b/Command/BaseCommand.php
@@ -416,8 +416,8 @@ abstract class BaseCommand extends ContainerAwareCommand
     protected function getMemoryLimit()
     {
         if (!isset($this->memoryLimit)) {
-            if ($this->getContainer()->hasParameter('afrihost_base_command.memory_limit')) {
-                $this->memoryLimit = $this->getContainer()->getParameter('afrihost_base_command.memory_limit');
+            if ($this->getContainer()->hasParameter('afrihost_base_command.php.memory_limit')) {
+                $this->memoryLimit = $this->getContainer()->getParameter('afrihost_base_command.php.memory_limit');
             }
         }
 

--- a/Command/BaseCommand.php
+++ b/Command/BaseCommand.php
@@ -66,6 +66,11 @@ abstract class BaseCommand extends ContainerAwareCommand
     private $lockFileFolder;
 
     /**
+     * @var string
+     */
+    private $memoryLimit;
+
+    /**
      * Provides default options for all commands. This function should be called explicitly (i.e. parent::configure())
      * if the configure function is overridden.
      */
@@ -117,6 +122,11 @@ abstract class BaseCommand extends ContainerAwareCommand
         // Override production settings of not showing errors
         error_reporting(E_ALL);
         ini_set('display_errors', 1);
+
+        // PHP Memory Limit:
+        if ($this->getMemoryLimit() !== null) {
+            ini_set('memory_limit', $this->getMemoryLimit());
+        }
 
         // Reflect to get leaf-class:
         if (empty($this->filename)) {
@@ -376,6 +386,38 @@ abstract class BaseCommand extends ContainerAwareCommand
         }
 
         return $this->lockFileFolder;
+    }
+
+    /**
+     * Set the memory limit to use for PHP.
+     * Integer in bytes, but shorthand is allowed: @link http://php.net/manual/en/faq.using.php#faq.using.shorthandbytes
+     * To set unlimited memory, use -1
+     * You may use anything valid at @link http://php.net/manual/en/ini.core.php#ini.memory-limit
+     *
+     * @param string $memoryLimit
+     * @return BaseCommand
+     */
+    public function setMemoryLimit($memoryLimit)
+    {
+        $this->memoryLimit = $memoryLimit;
+
+        return $this;
+    }
+
+    /**
+     * Get the memory limit set either via config.yml, or via $this->setMemoryLimit()
+     *
+     * @return string
+     */
+    public function getMemoryLimit()
+    {
+        if (!isset($this->memoryLimit)) {
+            if ($this->getContainer()->hasParameter('afrihost_base_command.memory_limit')) {
+                $this->memoryLimit = $this->getContainer()->getParameter('afrihost_base_command.memory_limit');
+            }
+        }
+
+        return $this->memoryLimit;
     }
 
 }

--- a/Command/BaseCommand.php
+++ b/Command/BaseCommand.php
@@ -399,6 +399,10 @@ abstract class BaseCommand extends ContainerAwareCommand
      */
     public function setMemoryLimit($memoryLimit)
     {
+        if (isset($this->memoryLimit) && (!is_null($this->logger))) {
+            $this->getLogger()->emergency('PHP MEMORY LIMIT CHANGING: from ' . $this->memoryLimit . ' to ' . $memoryLimit);
+        }
+
         $this->memoryLimit = $memoryLimit;
 
         return $this;

--- a/DependencyInjection/AfrihostBaseCommandExtension.php
+++ b/DependencyInjection/AfrihostBaseCommandExtension.php
@@ -21,6 +21,10 @@ class AfrihostBaseCommandExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
+        if (isset($config['memory_limit'])) {
+            $container->setParameter('afrihost_base_command.memory_limit', $config['memory_limit']);
+        }
+
         $container->setParameter('afrihost_base_command.logger.handler_strategies.default.file_extention', $config['logger']['handler_strategies']['default']['file_extention']);
         $container->setParameter('afrihost_base_command.locking.enabled', $config['locking']['enabled']);
         $container->setParameter('afrihost_base_command.locking.lock_file_folder', $config['locking']['lock_file_folder']);

--- a/DependencyInjection/AfrihostBaseCommandExtension.php
+++ b/DependencyInjection/AfrihostBaseCommandExtension.php
@@ -21,8 +21,8 @@ class AfrihostBaseCommandExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        if (isset($config['memory_limit'])) {
-            $container->setParameter('afrihost_base_command.memory_limit', $config['memory_limit']);
+        if (isset($config['php']['memory_limit'])) {
+            $container->setParameter('afrihost_base_command.php.memory_limit', $config['php']['memory_limit']);
         }
 
         $container->setParameter('afrihost_base_command.logger.handler_strategies.default.file_extention', $config['logger']['handler_strategies']['default']['file_extention']);

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -27,7 +27,12 @@ class Configuration implements ConfigurationInterface
         // @formatter:off
         $rootNode
             ->children()
-                ->scalarNode('memory_limit')->end()
+                ->arrayNode('php')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('memory_limit')->end()
+                    ->end()
+                ->end()
                 ->arrayNode('locking')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -27,6 +27,7 @@ class Configuration implements ConfigurationInterface
         // @formatter:off
         $rootNode
             ->children()
+                ->scalarNode('memory_limit')->end()
                 ->arrayNode('locking')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/Tests/Command/BaseCommandContainerTest.php
+++ b/Tests/Command/BaseCommandContainerTest.php
@@ -277,6 +277,14 @@ class BaseCommandContainerTest extends PHPUnit_Framework_TestCase
         $fs->remove('~/storage');
     }
 
+    public function testSetMemoryLimit()
+    {
+        $command = $this->registerCommand(new HelloWorldCommand());
+        EncapsulationViolator::invokeMethod($command, 'setMemoryLimit', array('1024M'));
+        $this->executeCommand($command);
+
+        $this->assertEquals('1024M', ini_get('memory_limit'));
+    }
 
     /* ################ *
      *  Helper Methods  *


### PR DESCRIPTION
**NB:** This is not complete with tests yet, I'd like to get feedback on this before I write tests to make sure we're thinking in the same direction.

I wanted to keep the configuration as close to what set_ini allows for 'memory_limit', which is integer for bytes, but shorthand is allowed, thus K, M, G and so on (1024 base)

Thus, the idea here is that the config looks something similar to below:

``` yaml
afrihost_base_command:
    memory_limit:  123M
```

3 states exist:
- No configuration overriding is done: The system will not touch the memory_limit ini setting, thus using whatever PHP is set to use
- Overwritten in config.yml: As above, it will be set to "123M" - which PHP will interpret at 123 MegaBytes (1024 base)
- Overwritten via the `$this->setMemoryLimit("256M")`: This will set the memory_limit to "256M" which PHP will interpret as 256 MebaBytes (1024 base)

Please give me your thoughts. If you're happy with this let me know and I'll write the tests and let you know when you can merge, otherwise I'll make the appropriate changes :)
