### PR TITLE
Support Symfony 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "type": "symfony-bundle",
     "require": {
         "php": ">=5.3.3",
-        "symfony/symfony": "~2.6",
+        "symfony/symfony": "~2.6|~3.0",
         "monolog/monolog": "~1.10"
     },
     "require-dev": {


### PR DESCRIPTION
I ran a couple of basic tests to ensure Symfony 3 compatibility.

It doesn't look like anything is used in this bundle that is deprecated/removed in SF3, but just check to make sure I haven't missed something.
