### PR TITLE
Build improvements for HHVM tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
       - php: 5.5
       - php: 5.6
       - php: 7.0
-      - php: hhvm
+      - php: hhvm=3.24
   allow_failures:
       - php: 7.0
       - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
       - php: hhvm=3.24
   allow_failures:
       - php: 7.0
-      - php: hhvm
+      - php: hhvm=3.24
 
 # Cache composer files for faster test times
 cache:


### PR DESCRIPTION
## Build Improvement
Set a strict HHVM version since the new version of PHPUnit seems to be failing on HHVM due to a PHP 7 feature it is using.