### PR TITLE
Hotfix/travis ci builds empty cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,9 @@ before_install:
   - if [ -n "$GH_ACCESS_TOKEN" ]; then composer config github-oauth.github.com $GH_ACCESS_TOKEN; fi;
   # Composer only updated in TravisCI containers when they build their images every month or so
   - composer self-update
-  - composer require symfony/symfony:${SYMFONY_VERSION}
 
 install:
+  - composer require symfony/symfony:${SYMFONY_VERSION}
   - if [ -z "$DEPENDENCIES" ]; then composer install --no-interaction --prefer-dist; fi;
   - if [ "$DEPENDENCIES" == "low" ]; then composer update --no-interaction  --prefer-dist --prefer-lowest; fi;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,12 +32,12 @@ before_install:
   - if [ -n "$GH_ACCESS_TOKEN" ]; then git config --global github.accesstoken $GH_ACCESS_TOKEN; fi;
   - if [ -n "$GH_ACCESS_TOKEN" ]; then composer config github-oauth.github.com $GH_ACCESS_TOKEN; fi;
   # Composer only updated in TravisCI containers when they build their images every month or so
-  - composer self-update
+  - travis_retry composer self-update
 
 install:
-  - composer require symfony/symfony:${SYMFONY_VERSION}
-  - if [ -z "$DEPENDENCIES" ]; then composer install --no-interaction --prefer-dist; fi;
-  - if [ "$DEPENDENCIES" == "low" ]; then composer update --no-interaction  --prefer-dist --prefer-lowest; fi;
+  - travis_retry composer require symfony/symfony:${SYMFONY_VERSION}
+  - if [ -z "$DEPENDENCIES" ]; then travis_retry composer install --no-interaction --prefer-dist; fi;
+  - if [ "$DEPENDENCIES" == "low" ]; then travis_retry composer update --no-interaction  --prefer-dist --prefer-lowest; fi;
 
 script:
   - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ jobs:
 # Cache composer files for faster test times
 cache:
   directories:
-    - vendor
     - $HOME/.composer/cache
 
 before_install:


### PR DESCRIPTION
This PR attempts to reduce the number of TravisCI Builds that error as a result of transient network issues in the build environment (see https://getcomposer.org/doc/articles/troubleshooting.md#degraded-mode) via the use of TravisCI's own `travis_retry` wrapper which will attempt the composer commands up to three times (see https://docs.travis-ci.com/user/common-build-problems/#travis_retry).

An example of such an error can be seen in: https://travis-ci.org/github/afrihost/BaseCommandBundle/builds/669578686

It also removes the `vendor/` folder from the TravisCI cache between builds in order to lower false positives during changes of packages used by our project. In practice, this has a minimal impact on build time as the composer cache is still configured to be cached between builds by TravisCI